### PR TITLE
feat(openapi/generator): add the x-omitempty extension 

### DIFF
--- a/openapi/generator_test.go
+++ b/openapi/generator_test.go
@@ -3,8 +3,8 @@ package openapi
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
+	"os"
 	"reflect"
 	"strconv"
 	"testing"
@@ -213,7 +213,7 @@ func TestSchemaFromComplex(t *testing.T) {
 		t.Error(err)
 	}
 	// see testdata/X.json.
-	expected, err := ioutil.ReadFile("../testdata/schemas/X.json")
+	expected, err := os.ReadFile("../testdata/schemas/X.json")
 	if err != nil {
 		t.Error(err)
 	}
@@ -234,7 +234,7 @@ func TestSchemaFromComplex(t *testing.T) {
 		t.Error(err)
 	}
 	// see testdata/Y.json.
-	expected, err = ioutil.ReadFile("../testdata/schemas/Y.json")
+	expected, err = os.ReadFile("../testdata/schemas/Y.json")
 	if err != nil {
 		t.Error(err)
 	}
@@ -550,7 +550,7 @@ func TestAddOperation(t *testing.T) {
 		t.Error(err)
 	}
 	// see testdata/schemas/path-item.json.
-	expected, err := ioutil.ReadFile("../testdata/schemas/path-item.json")
+	expected, err := os.ReadFile("../testdata/schemas/path-item.json")
 	if err != nil {
 		t.Error(err)
 	}

--- a/openapi/validation_test.go
+++ b/openapi/validation_test.go
@@ -2,7 +2,7 @@ package openapi
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,7 +52,7 @@ func TestSchemaValidation(t *testing.T) {
 		t.Error(err)
 	}
 	// see testdata/validation/len.json.
-	expected, err := ioutil.ReadFile("../testdata/schemas/validation.json")
+	expected, err := os.ReadFile("../testdata/schemas/validation.json")
 	if err != nil {
 		t.Error(err)
 	}

--- a/testdata/schemas/X.json
+++ b/testdata/schemas/X.json
@@ -2,89 +2,109 @@
     "type": "object",
     "properties": {
         "A": {
-            "type": "string"
+            "type": "string",
+            "x-omitempty": false
         },
         "B": {
-            "type": "integer",
             "format": "int32",
-            "nullable": true
+            "nullable": true,
+            "type": "integer",
+            "x-omitempty": false
         },
         "C": {
+            "deprecated": true,
             "type": "boolean",
-            "deprecated": true
+            "x-omitempty": false
         },
         "D": {
-            "type": "array",
             "items": {
                 "$ref": "#/components/schemas/Y"
-            }
+            },
+            "type": "array",
+            "x-omitempty": false
         },
         "E": {
-            "type": "array",
             "items": {
                 "$ref": "#/components/schemas/XXX"
             },
             "maxItems": 3,
-            "minItems": 3
+            "minItems": 3,
+            "type": "array",
+            "x-omitempty": false
         },
         "F": {
-            "$ref": "#/components/schemas/XXX"
+            "$ref": "#/components/schemas/XXX",
+            "x-omitempty": false
         },
         "G": {
-            "$ref": "#/components/schemas/Y"
+            "$ref": "#/components/schemas/Y",
+            "x-omitempty": false
         },
         "H": {
+            "format": "float",
             "type": "number",
-            "format": "float"
+            "x-omitempty": false
         },
         "I": {
+            "format": "date",
             "type": "string",
-            "format": "date"
+            "x-omitempty": false
         },
         "J": {
-            "type": "integer",
             "format": "int32",
-            "nullable": true
+            "nullable": true,
+            "type": "integer",
+            "x-omitempty": false
         },
         "K": {
-            "type": "object",
             "additionalProperties": {
                 "$ref": "#/components/schemas/Y"
-            }
+            },
+            "type": "object",
+            "x-omitempty": false
         },
         "N": {
-            "type": "object",
             "properties": {
                 "Na": {
-                    "type": "string"
+                    "type": "string",
+                    "x-omitempty": false
                 },
                 "Nb": {
-                    "type": "string"
+                    "type": "string",
+                    "x-omitempty": false
                 },
                 "Nc": {
+                    "format": "duration",
                     "type": "string",
-                    "format": "duration"
+                    "x-omitempty": false
                 }
-            }
+            },
+            "type": "object",
+            "x-omitempty": false
         },
-        "S": {
+        "NI": {
+            "format": "int32",
+            "nullable": true,
             "type": "integer",
-            "format": "int32"
-        },
-        "nnNnnN":{
-            "type":"string"
-        },
-        "data": {
-            "$ref": "#/components/schemas/V"
+            "x-omitempty": false
         },
         "NS": {
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-omitempty": false
         },
-        "NI" : {
-            "nullable": true,
+        "S": {
+            "format": "int32",
             "type": "integer",
-            "format": "int32"
+            "x-omitempty": false
+        },
+        "data": {
+            "$ref": "#/components/schemas/V",
+            "x-omitempty": false
+        },
+        "nnNnnN": {
+            "type": "string",
+            "x-omitempty": false
         }
     },
     "required": [

--- a/testdata/schemas/Y.json
+++ b/testdata/schemas/Y.json
@@ -2,38 +2,46 @@
     "type": "object",
     "properties": {
         "H": {
+            "format": "float",
             "type": "number",
-            "format": "float"
+            "x-omitempty": false
         },
         "I": {
+            "format": "date",
             "type": "string",
-            "format": "date"
+            "x-omitempty": false
         },
         "J": {
-            "type": "integer",
             "format": "int32",
-            "nullable": true
+            "nullable": true,
+            "type": "integer",
+            "x-omitempty": false
         },
         "K": {
-            "type": "object",
             "additionalProperties": {
                 "$ref": "#/components/schemas/Y"
-            }
+            },
+            "type": "object",
+            "x-omitempty": false
         },
         "N": {
-            "type": "object",
             "properties": {
                 "Na": {
-                    "type": "string"
+                    "type": "string",
+                    "x-omitempty": false
                 },
                 "Nb": {
-                    "type": "string"
+                    "type": "string",
+                    "x-omitempty": false
                 },
                 "Nc": {
+                    "format": "duration",
                     "type": "string",
-                    "format": "duration"
+                    "x-omitempty": false
                 }
-            }
+            },
+            "type": "object",
+            "x-omitempty": false
         }
     },
     "required": [

--- a/testdata/schemas/path-item.json
+++ b/testdata/schemas/path-item.json
@@ -18,15 +18,17 @@
         "summary": "ABC",
         "description": "XYZ",
         "operationId": "CreateTest",
-        "parameters": [{
+        "parameters": [
+            {
                 "name": "a",
                 "in": "path",
                 "description": "This is A",
                 "required": true,
                 "schema": {
-                    "type": "integer",
                     "description": "This is A",
-                    "format": "int32"
+                    "format": "int32",
+                    "type": "integer",
+                    "x-omitempty": false
                 }
             },
             {
@@ -35,9 +37,10 @@
                 "description": "This is B",
                 "required": true,
                 "schema": {
-                    "type": "string",
                     "description": "This is B",
-                    "format": "date-time"
+                    "format": "date-time",
+                    "type": "string",
+                    "x-omitempty": false
                 }
             },
             {
@@ -45,45 +48,49 @@
                 "in": "query",
                 "allowEmptyValue": true,
                 "schema": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "x-omitempty": false
                 }
             },
             {
                 "name": "i",
                 "in": "query",
                 "schema": {
-                    "type": "string"
+                    "type": "string",
+                    "x-omitempty": false
                 }
             },
             {
                 "name": "k",
                 "in": "query",
                 "schema": {
-                    "type": "array",
                     "items": {
-                        "type": "string",
                         "enum": [
                             "aaa",
                             "bbb",
                             "ccc"
-                        ]
-                    }
+                        ],
+                        "type": "string"
+                    },
+                    "type": "array",
+                    "x-omitempty": false
                 },
-                "explode": true,
-                "style": "form"
+                "style": "form",
+                "explode": true
             },
             {
                 "name": "xd",
                 "in": "query",
                 "schema": {
-                    "type": "integer",
-                    "format": "int32",
                     "default": 1,
                     "enum": [
                         1,
                         2,
                         3
-                    ]
+                    ],
+                    "format": "int32",
+                    "type": "integer",
+                    "x-omitempty": false
                 }
             },
             {
@@ -91,9 +98,10 @@
                 "in": "header",
                 "description": "This is C",
                 "schema": {
-                    "type": "string",
+                    "default": "test",
                     "description": "This is C",
-                    "default": "test"
+                    "type": "string",
+                    "x-omitempty": false
                 }
             }
         ],
@@ -110,18 +118,8 @@
             "201": {
                 "description": "Created",
                 "headers": {
-                    "X-Test-Header": {
-                        "description": "Test header",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "X-Test-Header-Alt": {
-                        "description": "Test header alt",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
+                    "X-Test-Header": {},
+                    "X-Test-Header-Alt": {}
                 },
                 "content": {
                     "application/json": {

--- a/testdata/schemas/validation.json
+++ b/testdata/schemas/validation.json
@@ -2,58 +2,68 @@
     "type": "object",
     "properties": {
         "A": {
-            "type": "string",
             "maxLength": 12,
-            "minLength": 12
+            "minLength": 12,
+            "type": "string",
+            "x-omitempty": false
         },
         "B": {
-            "type": "integer",
             "format": "int32",
             "maximum": 100,
-            "minimum": 5
+            "minimum": 5,
+            "type": "integer",
+            "x-omitempty": false
         },
         "C": {
-            "type": "array",
             "items": {
                 "type": "boolean"
             },
             "maxItems": 50,
-            "minItems": 50
+            "minItems": 50,
+            "type": "array",
+            "x-omitempty": false
         },
         "D": {
-            "type": "object",
             "additionalProperties": {
                 "type": "string"
             },
             "maxProperties": 5,
-            "minProperties": 5
+            "minProperties": 5,
+            "type": "object",
+            "x-omitempty": false
         },
         "E": {
-            "type": "string"
+            "type": "string",
+            "x-omitempty": false
         },
         "F": {
+            "maxLength": 7,
             "type": "string",
-            "maxLength": 7
+            "x-omitempty": false
         },
         "G": {
+            "minLength": 7,
             "type": "string",
-            "minLength": 7
+            "x-omitempty": false
         },
         "H": {
+            "format": "int32",
             "type": "integer",
-            "format": "int32"
+            "x-omitempty": false
         },
         "I": {
-            "type": "array",
             "items": {
                 "type": "string"
-            }
+            },
+            "type": "array",
+            "x-omitempty": false
         },
         "J": {
-            "type": "object",
             "additionalProperties": {
                 "type": "string"
-            }
+            },
+            "type": "object",
+            "x-omitempty": false
         }
     }
 }

--- a/testdata/spec.json
+++ b/testdata/spec.json
@@ -21,17 +21,6 @@
                 }
             }
         }
-    ],    
-    "security": [
-        {
-            "api_key": []
-        },
-        {
-            "oauth2": [
-                "write:pets",
-                "read:pets"
-            ]
-        }
     ],
     "paths": {
         "/test/{a}": {
@@ -45,7 +34,8 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "x-omitempty": false
                         }
                     }
                 ],
@@ -53,17 +43,12 @@
                     "200": {
                         "description": "OK",
                         "headers": {
-                            "X-Request-Id": {
-                                "description": "Unique request ID",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
+                            "X-Request-Id": {}
                         },
-                        "content":{
-                            "application/json":{
-                                "schema":{
-                                    "$ref":"#/components/schemas/FizzT"
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FizzT"
                                 }
                             }
                         }
@@ -76,12 +61,8 @@
                                     "type": "string"
                                 },
                                 "examples": {
-                                    "one": {
-                                        "value": "message1"
-                                    },
-                                    "two": {
-                                        "value": "message2"
-                                    }
+                                    "one": {},
+                                    "two": {}
                                 }
                             }
                         }
@@ -100,13 +81,7 @@
                     "429": {
                         "description": "Too Many Requests",
                         "headers": {
-                            "X-Rate-Limit": {
-                                "description": "Rate limit",
-                                "schema": {
-                                    "type": "integer",
-                                    "format": "int32"
-                                }
-                            }
+                            "X-Rate-Limit": {}
                         },
                         "content": {
                             "application/json": {
@@ -118,6 +93,7 @@
                     }
                 },
                 "deprecated": true,
+                "security": [],
                 "x-codeSamples": [
                     {
                         "lang": "Shell",
@@ -125,7 +101,6 @@
                         "source": "curl http://0.0.0.0:8080"
                     }
                 ],
-                "security": [],
                 "x-internal": true
             }
         },
@@ -138,7 +113,8 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "x-omitempty": false
                         }
                     },
                     {
@@ -146,15 +122,17 @@
                         "in": "path",
                         "required": true,
                         "schema": {
+                            "format": "int32",
                             "type": "integer",
-                            "format": "int32"
+                            "x-omitempty": false
                         }
                     },
                     {
                         "name": "q",
                         "in": "query",
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "x-omitempty": false
                         }
                     }
                 ],
@@ -183,7 +161,8 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "x-omitempty": false
                         }
                     }
                 ],
@@ -206,25 +185,28 @@
     },
     "components": {
         "schemas": {
-            "FizzCustomTime":{
-                "type":"object",
-                "description":"This is Z",
+            "FizzCustomTime": {
+                "type": "object",
+                "description": "This is Z",
                 "example": "2022-02-07T18:00:00"
             },
-            "FizzT":{
-                "type":"object",
-                "properties":{
-                    "x":{
-                        "type":"string",
-                        "description":"This is X"
+            "FizzT": {
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "description": "This is X",
+                        "type": "string",
+                        "x-omitempty": false
                     },
-                    "y":{
-                        "type":"integer",
-                        "description":"This is Y",
-                        "format":"int32"
+                    "y": {
+                        "description": "This is Y",
+                        "format": "int32",
+                        "type": "integer",
+                        "x-omitempty": false
                     },
-                    "z":{
-                        "$ref":"#/components/schemas/FizzCustomTime"
+                    "z": {
+                        "$ref": "#/components/schemas/FizzCustomTime",
+                        "x-omitempty": false
                     }
                 }
             },
@@ -232,34 +214,32 @@
                 "type": "object",
                 "properties": {
                     "message": {
+                        "description": "A short message",
                         "type": "string",
-                        "description": "A short message"
+                        "x-omitempty": false
                     },
                     "value": {
                         "description": "A nullable value of arbitrary type",
-                        "nullable": true
+                        "nullable": true,
+                        "x-omitempty": false
                     }
                 }
             }
         },
         "securitySchemes": {
-            "api_key": {
-                "type": "apiKey",
-                "name": "api_key",
-                "in": "header"
-            },
-            "oauth2": {
-                "type": "oauth2",
-                "flows": {
-                    "implicit": {
-                        "authorizationUrl": "https://example.com/api/oauth/dialog",
-                        "scopes": {
-                            "write:pets": "modify pets in your account",
-                            "read:pets": "read your pets"
-                        }
-                    }
-                }
-            }
+            "api_key": {},
+            "oauth2": {}
         }
-    }
+    },
+    "security": [
+        {
+            "api_key": []
+        },
+        {
+            "oauth2": [
+                "write:pets",
+                "read:pets"
+            ]
+        }
+    ]
 }

--- a/testdata/spec.yaml
+++ b/testdata/spec.yaml
@@ -9,16 +9,11 @@ servers:
   variables:
     basePath:
       enum:
-        - v1
-        - v2
-        - beta
+      - v1
+      - v2
+      - beta
       default: v2
       description: version of the API
-security:
-  - api_key: []
-  - oauth2:
-    - write:pets
-    - read:pets
 paths:
   /test/{a}:
     get:
@@ -32,7 +27,7 @@ paths:
         schema:
           type: string
       responses:
-        '200':
+        "200":
           description: OK
           headers:
             X-Request-Id:
@@ -43,7 +38,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FizzT'
-        '400':
+        "400":
           description: Bad Request
           content:
             application/json:
@@ -54,14 +49,14 @@ paths:
                   value: message1
                 two:
                   value: message2
-        '404':
+        "404":
           description: Not Found
           content:
             application/json:
               schema:
                 type: string
               example: not-found-example
-        '429':
+        "429":
           description: Too Many Requests
           headers:
             X-Rate-Limit:
@@ -74,11 +69,11 @@ paths:
               schema:
                 type: string
       deprecated: true
-      x-codeSamples:
-        - lang: Shell
-          label: v4.4
-          source: curl http://0.0.0.0:8080
       security: []
+      x-codeSamples:
+      - lang: Shell
+        label: v4.4
+        source: curl http://0.0.0.0:8080
       x-internal: true
   /test/{a}/{b}:
     get:
@@ -100,7 +95,7 @@ paths:
         schema:
           type: string
       responses:
-        '200':
+        "200":
           description: OK
       security:
       - {}
@@ -120,7 +115,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PostTestInput"
+              $ref: '#/components/schemas/PostTestInput'
       responses:
         "201":
           description: Created
@@ -147,20 +142,25 @@ components:
       properties:
         message:
           type: string
-          description: "A short message"
+          description: A short message
         value:
-          description: "A nullable value of arbitrary type"
+          description: A nullable value of arbitrary type
           nullable: true
   securitySchemes:
     api_key:
       type: apiKey
-      name: api_key
       in: header
+      name: api_key
     oauth2:
       type: oauth2
       flows:
         implicit:
           authorizationUrl: https://example.com/api/oauth/dialog
           scopes:
-            write:pets: modify pets in your account
             read:pets: read your pets
+            write:pets: modify pets in your account
+security:
+- api_key: []
+- oauth2:
+  - write:pets
+  - read:pets


### PR DESCRIPTION
… fields that contains an omitempty in json tag

Contexte to this upgrade

We currently do not have the possibility to decide weither a value should omit empty or not once the openAPI format is transcribed to Golang structures.

I have added a new value to the schema and reference structures called Extensions. This value will be able to handle all extra extensions we would like our components to hold. As of now only the "x-omitempty" is handled as it will search the json tag in a structure and place the value of this extension either to true or false.

But many other extensions could be added later on.
